### PR TITLE
Remove Prisma-specific steps from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,11 @@ FROM node:22-alpine AS development
 WORKDIR /app
 
 COPY package*.json ./
-COPY prisma ./prisma/
 
 RUN apk add --no-cache openssl
 RUN npm ci
 
 COPY . .
-
-RUN npx prisma generate
 
 EXPOSE 3000
 
@@ -22,14 +19,11 @@ FROM node:22-alpine AS production
 WORKDIR /app
 
 COPY package*.json ./
-COPY prisma ./prisma/
 
 RUN apk add --no-cache openssl
 RUN npm ci --only=production
 
 COPY . .
-
-RUN npx prisma generate
 RUN npm run build
 
 EXPOSE 3000


### PR DESCRIPTION
## Summary
- remove Prisma-specific copy and generation commands from the development and production stages of the Dockerfile after migrating to TypeORM
- ensure the image build no longer references the removed prisma directory

## Testing
- docker build . -t aid-test *(fails: docker CLI unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de56bb88a0832b88b05f207771d434