### PR TITLE
Fix SSL configuration handling in database module

### DIFF
--- a/src/database/database.module.ts
+++ b/src/database/database.module.ts
@@ -17,7 +17,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
         entities: [__dirname + '/../**/*.entity{.ts,.js}'],
         synchronize: false, // Never use true in production
         logging: configService.get('nodeEnv') === 'development',
-        ssl: configService.get('database.ssl') === 'true' ? { rejectUnauthorized: false } : false,
+        ssl: configService.get('database.ssl') ? { rejectUnauthorized: false } : false,
       }),
     }),
   ],


### PR DESCRIPTION
## Summary
- update the TypeORM SSL option to rely on the boolean value from configuration rather than a string comparison

## Testing
- npm run build *(fails: prisma.config.ts cannot find module 'prisma/config')*

------
https://chatgpt.com/codex/tasks/task_e_68de56bcf000832bad711543401df740